### PR TITLE
Update for backend to work with changes in Django1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - DJANGO=Django==1.5.10
   - DJANGO=Django==1.6.7
   - DJANGO=Django==1.7
+  - DJANGO=Django==1.7
 install:
   - pip install -q $DJANGO python-ldap mockldap --use-mirrors
 script: python manage.py test ldapdb examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - DJANGO=Django==1.5.10
   - DJANGO=Django==1.6.7
   - DJANGO=Django==1.7
-  - DJANGO=Django==1.7
+  - DJANGO=Django==1.8
 install:
   - pip install -q $DJANGO python-ldap mockldap --use-mirrors
 script: python manage.py test ldapdb examples

--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -32,11 +32,17 @@
 
 import ldap
 import django
+from pkg_resources import parse_version
 
-from django.db.backends.base.features import (BaseDatabaseFeatures)
-from django.db.backends.base.operations import (BaseDatabaseOperations)
-from django.db.backends.base.base import (BaseDatabaseWrapper)
-from django.db.backends.base.creation import BaseDatabaseCreation
+if parse_version(django.get_version()) < parse_version('1.8'):
+    from django.db.backends import (BaseDatabaseFeatures, BaseDatabaseOperations,
+                                BaseDatabaseWrapper)
+    from django.db.backends.creation import BaseDatabaseCreation
+else:
+    from django.db.backends.base.features import (BaseDatabaseFeatures)
+    from django.db.backends.base.operations import (BaseDatabaseOperations)
+    from django.db.backends.base.base import (BaseDatabaseWrapper)
+    from django.db.backends.base.creation import BaseDatabaseCreation
 
 
 class DatabaseCreation(BaseDatabaseCreation):

--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -33,9 +33,10 @@
 import ldap
 import django
 
-from django.db.backends import (BaseDatabaseFeatures, BaseDatabaseOperations,
-                                BaseDatabaseWrapper)
-from django.db.backends.creation import BaseDatabaseCreation
+from django.db.backends.base.features import (BaseDatabaseFeatures)
+from django.db.backends.base.operations import (BaseDatabaseOperations)
+from django.db.backends.base.base import (BaseDatabaseWrapper)
+from django.db.backends.base.creation import BaseDatabaseCreation
 
 
 class DatabaseCreation(BaseDatabaseCreation):

--- a/ldapdb/backends/ldap/compiler.py
+++ b/ldapdb/backends/ldap/compiler.py
@@ -31,9 +31,11 @@
 #
 
 import ldap
+import django
 
 from django.db.models.sql import aggregates, compiler
 from django.db.models.sql.where import AND, OR
+from pkg_resources import parse_version
 
 
 def get_lookup_operator(lookup_type):
@@ -272,6 +274,6 @@ class SQLUpdateCompiler(compiler.SQLUpdateCompiler, SQLCompiler):
 class SQLAggregateCompiler(compiler.SQLAggregateCompiler, SQLCompiler):
     pass
 
-
-class SQLDateCompiler(compiler.SQLDateCompiler, SQLCompiler):
-    pass
+if parse_version(django.get_version()) < parse_version('1.8'):
+    class SQLDateCompiler(compiler.SQLDateCompiler, SQLCompiler):
+        pass


### PR DESCRIPTION
First of all, sorry if what I'm doing is annoying, I'm just discovering github.

The changes in the travis.yml file and in the base.py file make it possible to use django-ldapdb with Django 1.8

The Django team changed the way the backend code was organized and thus made it impossible for ldapdb to work.
Credit goes to foxmask on #django-fr@freenode.org