### PR TITLE
Support Django v1.8.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - DJANGO=Django==1.5.10
   - DJANGO=Django==1.6.7
   - DJANGO=Django==1.7
+  - DJANGO=Django==1.8
 install:
   - pip install -q $DJANGO python-ldap mockldap --use-mirrors
 script: python manage.py test ldapdb examples

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ LDAP backend is very staightforward, you simply inherit from
 _ldapdb.models.Model_ and declare the fields in the same way as for regular
 models. You can even edit the LDAP entries using Django's admin interface.
 
-_django-ldapdb_ requires Django version 1.2.x, 1.3.x, 1.4.x, 1.5.x, 1.6.x
-or 1.7.x.
+_django-ldapdb_ requires Django version 1.2.x, 1.3.x, 1.4.x, 1.5.x, 1.6.x,
+1.7.x or 1.8.x.
 
 _django-ldapdb_ is distributed under the BSD license, see the LICENSE
 file for details. See AUTHORS file for a full list of contributors.


### PR DESCRIPTION
This keeps backward compatibility with previously supported Django versions down
to v1.2.x.
Count aggregates had to be supported for Django v1.8.x therefore changes were
made to get Count aggregates supported for all other supported Django versions.