### PR TITLE
Allow for using 'python setup.py test' to run test suite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
   - DJANGO=Django==1.8
 install:
   - pip install -q $DJANGO python-ldap mockldap --use-mirrors
-script: python manage.py test ldapdb examples
+script: python setup.py test

--- a/manage.py
+++ b/manage.py
@@ -2,9 +2,17 @@
 import os
 import sys
 
+import django
+from django.core.management import execute_from_command_line
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+def run_tests():
+    if django.VERSION < (1, 6):
+        execute_from_command_line([os.path.abspath(__file__), 'test', 'ldapdb', 'examples'])
+    else:
+        execute_from_command_line([os.path.abspath(__file__), 'test'])
+    sys.exit(0)
+
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
-
-    from django.core.management import execute_from_command_line
-
     execute_from_command_line(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(
     ],
     tests_require=[
         'mockldap>=0.1',
-    ]
+    ],
+    test_suite = 'manage.run_tests'
 )


### PR DESCRIPTION
It would be great if the test suite can be run through 'python setup.py test'. Using 'python setup.py test' seems universal and anyone attempting to run test suites of any Python module would first try running this. Also takes away the need for users to figure out how they need to run the test suite (slight difference when using Django < 1.6).